### PR TITLE
po-select/DTHFUI-1003 - problemas de responsividade em alguns browsers

### DIFF
--- a/src/css/components/po-field/po-checkbox-group/po-checkbox-group.css
+++ b/src/css/components/po-field/po-checkbox-group/po-checkbox-group.css
@@ -18,6 +18,10 @@
   visibility: hidden;
 }
 
+.po-checkbox-group-item .po-checkbox-group-input {
+  width: 0;
+}
+
 .po-checkbox-group-input+.po-checkbox-group-label:before {
   background-color: var(--color-checkbox-group-background-color);
   border: solid 1px var(--color-checkbox-group-border-input);

--- a/src/css/components/po-field/po-field-container/po-field-container.css
+++ b/src/css/components/po-field/po-field-container/po-field-container.css
@@ -12,6 +12,10 @@
   }
 }
 
+.po-field-container {
+  position: relative;
+}
+
 /* Classe que possibilita colocar o botão de clean na mesma linha, */
 .po-field-container-content {
   padding: 8px 0;

--- a/src/css/components/po-field/po-select/po-select.css
+++ b/src/css/components/po-field/po-select/po-select.css
@@ -133,6 +133,7 @@
 .po-select-mobile {
   color: transparent;
   height: 3.5em;
+  position: absolute;
   width: 96%;
   z-index: 1;
 }


### PR DESCRIPTION
**PO SELECT**
[DTHFUI-1003](http://jiraproducao.totvs.com.br/browse/DTHFUI-1003)

DTHFUI-1258 - po-select - problemas de responsividade em alguns browsers 

**Situação**
O tamanho do select estourava no iPad, sugiro a leitura dos comentários da Issue para complementar a situação.

**Solução**
Adicionado position relative para o pai do elemento e position absolute para o elemento, assim o tamanho do select fica limitado.

**Simulação**
Abrir o sample labs do `po-page-default` no modo mobile, de preferência no iPad e ao utilizar o select visualizar o tamanho dos elementos. 

Importante validar se houve algum efeito colateral nos componentes que utilizam a classe `po-field-container`.