### PR TITLE
build(gulp): altera a pasta gerada na distribuição de po-theme para style

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,8 @@ const customProperties = require('postcss-custom-properties')
 const importCss = require('postcss-import');
 const nested = require('postcss-nested');
 
+const distDirectory = 'style';
+
 const capitalize = string =>
   string.split('-')
     .map(part => part.charAt(0).toUpperCase() + part.substring(1).toLowerCase())
@@ -31,7 +33,7 @@ const cleanTemp = () => del('./.temp');
 const cleanThemeDir = () => del('./dist');
 
 const copyThemeAssets = () =>
-  src('./src/assets/**/*.*').pipe(dest(`./dist/po-theme${argv.theme ? '-' + argv.theme : ''}/`));
+  src('./src/assets/**/*.*').pipe(dest(`./dist/${distDirectory}${argv.theme ? '-' + argv.theme : ''}/`));
 
 const copyThemePackageJson = () =>
   src('package.json')
@@ -46,7 +48,7 @@ const copyThemePackageJson = () =>
 
       file.contents = new Buffer(JSON.stringify(contents, null, 2), 'utf-8');
     }))
-    .pipe(dest(`./dist/po-theme${argv.theme ? '-' + argv.theme : ''}/`));
+    .pipe(dest(`./dist/${distDirectory}${argv.theme ? '-' + argv.theme : ''}/`));
 
 const prepareThemeCss = () => src('./src/**/*.css').pipe(dest('./.temp'));
 
@@ -73,7 +75,7 @@ const buildThemeCss = () =>
       console.log(err.toString());
       this.emit('end');
     })
-    .pipe(dest(`./dist/po-theme${argv.theme ? '-' + argv.theme : ''}/`));
+    .pipe(dest(`./dist/${distDirectory}${argv.theme ? '-' + argv.theme : ''}/`));
 
 // Tarefa otimizada para desenvolvimento
 const buildDevThemeCss = () =>
@@ -93,7 +95,7 @@ const buildDevThemeCss = () =>
       console.log(err.toString());
       this.emit('end');
     })
-    .pipe(dest(`./dist/po-theme${argv.theme ? '-' + argv.theme : ''}/`));
+    .pipe(dest(`./dist/${distDirectory}${argv.theme ? '-' + argv.theme : ''}/`));
 
 const buildTheme = series(
   cleanTemp,
@@ -116,7 +118,7 @@ const copyAppAssets = () => src('./src/app/assets/**/*.*').pipe(dest('./app-dist
 const copyAppComponents = () => src(['./src/css/**/*.html', './src/css/**/*.js']).pipe(dest('./app-dist/css'));
 
 const copyThemeToApp = () =>
-  src([`./dist/po-theme${argv.theme ? '-' + argv.theme : ''}/**/*.*`, '!./dist/*.json'])
+  src([`./dist/${distDirectory}${argv.theme ? '-' + argv.theme : ''}/**/*.*`, '!./dist/*.json'])
     .pipe(dest('./app-dist/assets/'));
 
 const buildAppJs = () =>


### PR DESCRIPTION
**DTHFUI-1293** 

**Situação:**
Repositório do @portinari/style está gerando a pasta com o nome incorreto

**Solução:**
Altera a pasta gerada na distribuição de po-theme para style.

**Simulação:**
Gerar a distribuição utilizando o comando `npm run build` e verificar se a pasta gerada está com o nome "style". Também é importante pegar esta pasta e colocar no `node_modules `do portinari-angular para verificar se o css continua funcionando normalmente.
