### PR TITLE
fix(menu): corrige comportamento do grid system no template

### DIFF
--- a/src/css/components/po-menu/po-menu.css
+++ b/src/css/components/po-menu/po-menu.css
@@ -235,6 +235,7 @@
 
 .po-menu-header-template {
   display: inline-block;
+  width: 100%;
 }
 
 .po-menu-badge-alert, .po-menu-badge-alert-collapsed {


### PR DESCRIPTION
PO-MENU

DTHFUI-1626

Situação:
Ao definir 12 colunas para um elemento no Menu Header Template, o mesmo não ocupava a largura total.

Solução:
Definida a largura em cem por cento na classe utilizada no Menu Header Template do menu.

Simulação:
```
<po-menu [p-menus]="[{ label: 'Item', link: '/'}]" p-filter>
   <ng-template p-menu-header-template>
    <po-combo class="po-md-12" name="name" [(ngModel)]="name" [p-options]="[{value: '1', label: '1'}]"> </po-combo>
  </ng-template>
</po-menu>
```