### PR TITLE
fix(table): corrige scroll do eixo y no IE

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -52,6 +52,7 @@
 .po-table-main-container {
   line-height: normal;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .po-table-wrapper {


### PR DESCRIPTION
**Qual o comportamento atual?**
Ao utilizar o lookup está aparecendo dois scrolls verticais no IE.

**Qual o novo comportamento?**
Deve aparecer apenas um scroll na tabela e este scroll deve estar no conteúdo.

**Simulação:**
a correção do problema pode ser visto ao utilizar estes componentes no portal.

[PR do portinari-theme](https://totvstfs.visualstudio.com/THF/_git/portinari-theme/pullrequest/14269?_a=overview)

OBS.: importante testar no mobile.

