### PR TITLE
Ajuste documentacao desenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,23 @@ Antes de desenvolver um novo componente, verifique se o protótipo tem a especif
 2. Fica observando alterações no projeto e recria o build do projeto em tempo de desenvolvimento
 `npm run watch` ou `yarn watch`
 
-3. Inicia o servidor para testar o projeto
+    - Quando você deseja especificar um tema, é necessário adicionar
+    `-- --theme <nomedotema>`
+
+    **Exemplo**: `npm run watch -- --theme green`
+    
+    **Nome do tema**: é o sufixo relacionado ao arquivo `po-theme-<sufixo>.css`, localizado em `src/app/css/themes`;
+
+3. Inicia o servidor (http-server) para testar o projeto
 `npm run dev` ou `yarn dev`
+
+    - Utilizando o `npm run watch` e o `npm run dev`, a cada alteração, apenas dê o refresh na página para visualizar a mesma;
+
 
 Outros scripts:
 * Faz o build do projeto
 `npm run build` ou `yarn build`
+    * Também é possível informar um tema específico adicionando `-- --theme <nomedotema>`
 
 # Contribuição
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,11 +154,15 @@ const watchers = () => {
   console.warn('\n');
   console.warn('   ╔═════════════════════════════════════════════════╗');
   console.warn('   ║                                                 ║');
+  console.warn('       >> TEMA UTILIZADO: ' + argv.theme || 'default' + ' <<');
+  console.warn('   ║                                                 ║');
   console.warn('   ║   NÃO ESQUEÇA DE INICIAR O SEU SERVIDOR HTTP!   ║');
   console.warn('   ║                                                 ║');
-  console.warn('   ║   Use o servidor que você achar melhor:         ║');
+  console.warn('   ║   Execute em outro terminal (http-server):      ║');
+  console.warn('   ║   - npm run dev                                 ║');
+  console.warn('   ║                                                 ║');
+  console.warn('   ║   Ou use o servidor que você achar melhor:      ║');
   console.warn('   ║   - live-server                                 ║');
-  console.warn('   ║   - http-server                                 ║');
   console.warn('   ║   - tanto faz ...                               ║');
   console.warn('   ║                                                 ║');
   console.warn('   ║   Ao atualizar um arquivo CSS ou HTML a sua     ║');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "gulp build",
     "build:app": "gulp build:app",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+    "dev": "http-server ./app-dist -o -c-1"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.0",
@@ -24,6 +25,7 @@
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-tap": "^1.0.1",
+    "http-server": "^0.11.1",
     "postcss-apply": "^0.12.0",
     "postcss-custom-properties": "^8.0.10",
     "postcss-import": "^12.0.1",


### PR DESCRIPTION
Melhoria em relação a documentação para iniciar o desenvolvimento de um tema novo e conseguir validar o esquema de cores.

- Adicionado a dependência de desenvolvimento: http-server;
- Incluído script "dev" no package.json para iniciar o servidor http a partir do diretório de compilação;
- Incrementado a documentação com as informações para build de outros temas;
- Ajustado script gulp para informar o tema que está sendo utilizado (apenas quando watch);