### PR TITLE
fix(toolbar): corrige o funcionamento sem o p-profile

### DIFF
--- a/src/css/components/po-toolbar/po-toolbar.html
+++ b/src/css/components/po-toolbar/po-toolbar.html
@@ -25,7 +25,9 @@
             <div class="po-toolbar-notification-badge">0</div>
           </div>
           <div class="po-toolbar-profile po-clickable">
-            <span class="po-icon po-icon-user po-toolbar-icon"></span>
+            <div class="po-avatar po-avatar-xs">
+              <img alt="" class="po-avatar-image">
+            </div>
           </div>
         </div>
       </div>
@@ -43,7 +45,9 @@
             <span class="po-icon po-icon-notification po-toolbar-icon"></span>
           </div>
           <div class="po-toolbar-profile po-clickable">
-            <span class="po-icon po-icon-user po-toolbar-icon"></span>
+            <div class="po-avatar po-avatar-xs">
+              <img alt="" class="po-avatar-image">
+            </div>
           </div>
         </div>
       </div>
@@ -76,7 +80,9 @@
             <div class="po-toolbar-notification-badge">3</div>
           </div>
           <div class="po-toolbar-profile po-clickable">
-            <span class="po-icon po-icon-user po-toolbar-icon"></span>
+            <div class="po-avatar po-avatar-xs">
+              <img alt="" class="po-avatar-image">
+            </div>
           </div>
         </div>
       </div>
@@ -107,7 +113,9 @@
             <div class="po-toolbar-notification-badge">3</div>
           </div>
           <div class="po-toolbar-profile po-clickable">
-            <span class="po-icon po-icon-user po-toolbar-icon"></span>
+            <div class="po-avatar po-avatar-xs">
+              <img alt="" class="po-avatar-image">
+            </div>
           </div>
         </div>
       </div>
@@ -123,14 +131,16 @@
             <div class="po-toolbar-notification-badge">7</div>
           </div>
           <div class="po-toolbar-profile po-clickable">
-            <span class="po-icon po-icon-user po-toolbar-icon"></span>
+            <div class="po-avatar po-avatar-xs">
+              <img alt="" class="po-avatar-image">
+            </div>
 
-              <div class="po-popup" style="margin-top: 8px; margin-left: -177px">
+              <div class="po-popup" style="margin-top: 8px; margin-left: -222px">
                 <div class="po-popup-arrow po-arrow-top-right"></div>
 
                 <div class="po-toolbar-profile-item-header">
                   <div class="po-avatar po-avatar-sm po-toolbar-profile-item-avatar">
-                    <img src="./assets/images/portinari-logo-user.svg" alt="" class="po-avatar-image">
+                    <img alt="" class="po-avatar-image">
                   </div>
                   <div>
                     <div class="po-toolbar-profile-item-header-title">


### PR DESCRIPTION
**PO-TOOLBAR**

**DTHFUI-1936**

***

**PR Checklist**

- [x] HTML
- [ ] CSS

***

**Qual o comportamento atual?**
O problema ocorre dada a falta de definição da propriedade `p-profile` tendo a definição de uma `p-profile-actions` definida no mesmo contexto.

**Qual o novo comportamento?**
Agora o componente permite utilizar a propriedade `p-profile-actions` sem que haja um `p-profile` definido.

**Simulação**
É possível simular o problema removendo a definição de `p-profile` no _sample logged_ do componente.

UI: https://github.com/portinariui/portinari-angular/pull/88