### PR TITLE
feat(tag): permitir o uso da paleta de cores e ícones

### DIFF
--- a/src/css/components/po-tag/po-tag.css
+++ b/src/css/components/po-tag/po-tag.css
@@ -19,13 +19,37 @@
   white-space: nowrap;
 }
 
-.po-tag {
-  border-radius: 3px;
-  color: var(--color-tag-color);
+.po-tag-sub-container {
   display: inline-table;
   height: 20px;
-  padding: 2px 8px;
+  position: relative;
+  vertical-align: middle;
+}
+
+.po-tag {
+  border: none;
+  border-radius: 3px;
+  color: var(--color-tag-color);
+  display: table;
+  height: 20px;
+  padding: 0 8px;
   word-wrap: break-word;
+}
+
+.po-tag:focus {
+  outline: none;
+}
+
+.po-tag:focus:before {
+  border-radius: 1px;
+  border: 2px dashed var(--color-tag-border-color-dashed-focus);
+  box-sizing: border-box;
+  content: "";
+  height: calc(100% + 8px);
+  left: -4px;
+  position: absolute;
+  top: -4px;
+  width: calc(100% + 8px);
 }
 
 .po-tag-value {
@@ -36,7 +60,7 @@
 
 .po-tag-title {
   display: table;
-  padding-bottom: 5px; /* alinhamento com po-info vertical */
+  padding-bottom: 8px; /* alinhamento com po-info vertical */
   vertical-align: middle;
 }
 
@@ -54,10 +78,6 @@
   padding: 0 8px 0 0;
 }
 
-.po-tag-container-horizontal .po-tag-value {
-  line-height: 8px;
-}
-
 .po-tag .po-icon {
   @apply --font-tag-font-icon;
   display: table-cell;
@@ -65,7 +85,7 @@
 }
 
 .po-tag .po-icon::before {
-  margin: 0 2px 0 -2px;
+  margin: 0 4px 0 -2px;
 }
 
 .po-tag-danger {

--- a/src/css/components/po-tag/po-tag.html
+++ b/src/css/components/po-tag/po-tag.html
@@ -4,26 +4,34 @@
       <h4 class="po-mb-md-2">Simples</h4>
 
       <div class="po-tag-container">
-        <div class="po-tag po-tag-success">
-          <span class="po-tag-value">Sucesso</span>
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-success" tabindex="0">
+            <span class="po-tag-value">Sucesso</span>
+          </div>
         </div>
       </div>
 
       <div class="po-tag-container">
-        <div class="po-tag po-tag-warning">
-          <span class="po-tag-value">Atenção</span>
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-warning" tabindex="0">
+            <span class="po-tag-value">Atenção</span>
+          </div>
         </div>
       </div>
 
       <div class="po-tag-container">
-        <div class="po-tag po-tag-danger">
-          <span class="po-tag-value">Erro</span>
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-danger" tabindex="0">
+            <span class="po-tag-value">Erro</span>
+          </div>
         </div>
       </div>
 
       <div class="po-tag-container">
-        <div class="po-tag po-tag-info">
-          <span class="po-tag-value">Informação</span>
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+            <span class="po-tag-value">Informação</span>
+          </div>
         </div>
       </div>
     </div>
@@ -31,24 +39,252 @@
     <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
       <h4 class="po-mb-md-2">Ícones</h4>
 
-      <div class="po-tag po-tag-success">
-        <span class="po-icon po-icon-ok"></span>
-        <span class="po-tag-value">Sucesso</span>
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-success" tabindex="0">
+            <span class="po-icon po-icon-ok"></span>
+            <span class="po-tag-value">Sucesso</span>
+          </div>
+        </div>
       </div>
 
-      <div class="po-tag po-tag-warning">
-        <span class="po-icon po-icon-warning"></span>
-        <span class="po-tag-value">Atenção</span>
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-warning" tabindex="0">
+            <span class="po-icon po-icon-warning"></span>
+            <span class="po-tag-value">Atenção</span>
+          </div>
+        </div>
       </div>
 
-      <div class="po-tag po-tag-danger">
-        <span class="po-icon po-icon-close"></span>
-        <span class="po-tag-value">Erro</span>
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-danger" tabindex="0">
+            <span class="po-icon po-icon-close"></span>
+            <span class="po-tag-value">Erro</span>
+          </div>
+        </div>
       </div>
 
-      <div class="po-tag po-tag-info">
-        <span class="po-icon po-icon-info"></span>
-        <span class="po-tag-value">Informação</span>
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+            <span class="po-icon po-icon-info"></span>
+            <span class="po-tag-value">Informação</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
+      <h4 class="po-mb-md-2">Utilizando paleta de cores</h4>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-01" tabindex="0">
+            <span class="po-tag-value">Color 01</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-02" tabindex="0">
+            <span class="po-tag-value">Color 02</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-03" tabindex="0">
+            <span class="po-tag-value">Color 03</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-04" tabindex="0">
+            <span class="po-tag-value">Color 04</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-05" tabindex="0">
+            <span class="po-tag-value">Color 05</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-06" tabindex="0">
+            <span class="po-tag-value">Color 06</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-07" tabindex="0">
+            <span class="po-tag-value">Color 07</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-08" tabindex="0">
+            <span class="po-tag-value">Color 08</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-09" tabindex="0">
+            <span class="po-tag-value">Color 09</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-10" tabindex="0">
+            <span class="po-tag-value">Color 10</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-11" tabindex="0">
+            <span class="po-tag-value">Color 11</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-12" tabindex="0">
+            <span class="po-tag-value">Color 12</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
+      <h4 class="po-mb-md-2">Utilizando paleta de cores e ícones</h4>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-01" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 01</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-02" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 02</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-03" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 03</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-04" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 04</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-05" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 05</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-06" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 06</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-07" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 07</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-08" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 08</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-09" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 09</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-10" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 10</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-11" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 11</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="po-tag-container">
+        <div class="po-tag-sub-container">
+          <div class="po-tag po-tag-no-horizontal po-color-12" tabindex="0">
+            <span class="po-icon po-icon-star"></span>
+            <span class="po-tag-value">Color 12</span>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -60,9 +296,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Sucesso</span>
           </div>
-          <div class="po-tag po-tag-success">
-            <span class="po-icon po-icon-ok"></span>
-            <span class="po-tag-value">Sucesso</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-success" tabindex="0">
+              <span class="po-tag-value">Sucesso</span>
+            </div>
           </div>
         </div>
 
@@ -70,8 +307,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Atenção</span>
           </div>
-          <div class="po-tag po-tag-warning">
-            <span class="po-tag-value">Atenção</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-warning" tabindex="0">
+              <span class="po-tag-value">Atenção</span>
+            </div>
           </div>
         </div>
 
@@ -79,8 +318,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Erro</span>
           </div>
-          <div class="po-tag po-tag-danger">
-            <span class="po-tag-value">Erro</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-danger" tabindex="0">
+              <span class="po-tag-value">Erro</span>
+            </div>
           </div>
         </div>
 
@@ -88,8 +329,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Informação</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-tag-value">Informação</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+              <span class="po-tag-value">Informação</span>
+            </div>
           </div>
         </div>
       </div>
@@ -102,9 +345,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Sucesso</span>
           </div>
-          <div class="po-tag po-tag-success">
-            <span class="po-icon po-icon-ok"></span>
-            <span class="po-tag-value">Sucesso</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-success" tabindex="0">
+              <span class="po-icon po-icon-ok"></span>
+              <span class="po-tag-value">Sucesso</span>
+            </div>
           </div>
         </div>
 
@@ -112,9 +357,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Atenção</span>
           </div>
-          <div class="po-tag po-tag-warning">
-            <span class="po-icon po-icon-warning"></span>
-            <span class="po-tag-value">Atenção</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-warning" tabindex="0">
+              <span class="po-icon po-icon-warning"></span>
+              <span class="po-tag-value">Atenção</span>
+            </div>
           </div>
         </div>
 
@@ -122,9 +369,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Erro</span>
           </div>
-          <div class="po-tag po-tag-danger">
-            <span class="po-icon po-icon-close"></span>
-            <span class="po-tag-value">Erro</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-danger" tabindex="0">
+              <span class="po-icon po-icon-close"></span>
+              <span class="po-tag-value">Erro</span>
+            </div>
           </div>
         </div>
 
@@ -132,24 +381,28 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Informação</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-icon po-icon-info"></span>
-            <span class="po-tag-value">Informação</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+              <span class="po-icon po-icon-info"></span>
+              <span class="po-tag-value">Informação</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
 
     <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
-      <h4 class="po-mb-md-2">Horizontal</h4>
+      <h4 class="po-mb-md-2">Label - Horizontal</h4>
 
       <div class="po-row">
         <div class="po-tag-container po-tag-container-horizontal po-md-3">
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Sucesso:</span>
           </div>
-          <div class="po-tag po-tag-success">
-            <span class="po-tag-value">Sucesso</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-success" tabindex="0">
+              <span class="po-tag-value">Sucesso</span>
+            </div>
           </div>
         </div>
 
@@ -157,8 +410,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Atenção:</span>
           </div>
-          <div class="po-tag po-tag-warning">
-            <span class="po-tag-value">Atenção</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-warning" tabindex="0">
+              <span class="po-tag-value">Atenção</span>
+            </div>
           </div>
         </div>
 
@@ -166,8 +421,10 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Erro:</span>
           </div>
-          <div class="po-tag po-tag-danger">
-            <span class="po-tag-value">Erro</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-danger" tabindex="0">
+              <span class="po-tag-value">Erro</span>
+            </div>
           </div>
         </div>
 
@@ -175,15 +432,17 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Informação:</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-tag-value">Informação</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-info" tabindex="0">
+              <span class="po-tag-value">Informação</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
 
     <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
-      <h4 class="po-mb-md-2">Label e Ícones - Horizontal</h4>
+      <h4 class="po-mb-md-2">Label e ícones - Horizontal</h4>
 
       <div class="po-row">
 
@@ -191,9 +450,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Sucesso:</span>
           </div>
-          <div class="po-tag po-tag-success">
-            <span class="po-icon po-icon-ok"></span>
-            <span class="po-tag-value">Sucesso</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-success" tabindex="0">
+              <span class="po-icon po-icon-ok"></span>
+              <span class="po-tag-value">Sucesso</span>
+            </div>
           </div>
         </div>
 
@@ -201,9 +462,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Atenção:</span>
           </div>
-          <div class="po-tag po-tag-warning">
-            <span class="po-icon po-icon-warning"></span>
-            <span class="po-tag-value">Atenção</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-warning" tabindex="0">
+              <span class="po-icon po-icon-warning"></span>
+              <span class="po-tag-value">Atenção</span>
+            </div>
           </div>
         </div>
 
@@ -211,9 +474,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Erro:</span>
           </div>
-          <div class="po-tag po-tag-danger">
-            <span class="po-icon po-icon-close"></span>
-            <span class="po-tag-value">Erro</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-danger" tabindex="0">
+              <span class="po-icon po-icon-close"></span>
+              <span class="po-tag-value">Erro</span>
+            </div>
           </div>
         </div>
 
@@ -221,9 +486,11 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Informação:</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-icon po-icon-info"></span>
-            <span class="po-tag-value">Informação</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-info" tabindex="0">
+              <span class="po-icon po-icon-info"></span>
+              <span class="po-tag-value">Informação</span>
+            </div>
           </div>
         </div>
       </div>
@@ -233,13 +500,14 @@
       <h4 class="po-mb-md-2">Alinhamento entre Info e Tag</h4>
 
       <div class="po-row po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
-        <div class="po-info po-field-container po-md-2">
-          <div class="po-field-container-title po-info-label-horizontal po-text-nowrap">
-            <span class="po-info-label">Portinari Info:</span>
+        <div class="po-tag-container po-tag-container-horizontal po-md-2">
+          <div class="po-tag-title po-text-nowrap">
+            <span class="po-tag-label">Portinari Tag</span>
           </div>
-
-          <div class="po-info-value-horizontal">
-            <span class="po-info-value"> Horizontal </span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-info" tabindex="0">
+              <span class="po-tag-value">Horizontal</span>
+            </div>
           </div>
         </div>
 
@@ -247,30 +515,24 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Portinari Tag</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-tag-value">Horizontal</span>
-          </div>
-        </div>
-
-        <div class="po-tag-container po-tag-container-horizontal po-md-2">
-          <div class="po-tag-title po-text-nowrap">
-            <span class="po-tag-label">Portinari Tag</span>
-          </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-icon po-icon-info"></span>
-            <span class="po-tag-value">Horizontal</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-horizontal po-tag-info" tabindex="0">
+              <span class="po-icon po-icon-info"></span>
+              <span class="po-tag-value">Horizontal</span>
+            </div>
           </div>
         </div>
       </div>
 
       <div class="po-row po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
-        <div class="po-info po-field-container po-md-2">
-          <div class="po-field-container-title">
-            <span class="po-field-title">Portinari Info</span>
+        <div class="po-tag-container po-md-2">
+          <div class="po-tag-title po-text-nowrap">
+            <span class="po-tag-label">Portinari Tag</span>
           </div>
-
-          <div class="po-field-container-content">
-            <span class="po-info-value">Vertical</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+              <span class="po-tag-value">Vertical</span>
+            </div>
           </div>
         </div>
 
@@ -278,31 +540,27 @@
           <div class="po-tag-title po-text-nowrap">
             <span class="po-tag-label">Portinari Tag</span>
           </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-tag-value">Vertical</span>
-          </div>
-        </div>
-
-        <div class="po-tag-container po-md-2">
-          <div class="po-tag-title po-text-nowrap">
-            <span class="po-tag-label">Portinari Tag</span>
-          </div>
-          <div class="po-tag po-tag-info">
-            <span class="po-icon po-icon-info"></span>
-            <span class="po-tag-value">Vertical</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-info" tabindex="0">
+              <span class="po-icon po-icon-info"></span>
+              <span class="po-tag-value">Vertical</span>
+            </div>
           </div>
         </div>
       </div>
 
       <div class="po-mb-sm-4 po-mb-md-4 po-mb-lg-4">
         <h4 class="po-mb-md-2">Clicável</h4>
-  
+
         <div class="po-tag-container">
-          <div class="po-tag po-tag-info po-clickable">
-            <span class="po-tag-value">Informação</span>
+          <div class="po-tag-sub-container">
+            <div class="po-tag po-tag-no-horizontal po-tag-info po-clickable" tabindex="0">
+              <span class="po-tag-value">Informação</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>  
+
+    </div>
   </section>
 </article>

--- a/src/css/themes/po-theme-default.css
+++ b/src/css/themes/po-theme-default.css
@@ -969,6 +969,8 @@
   TAG
 \*------------------------------------*/
 
+  --color-tag-border-color-dashed-focus: var(--color-secondary);
+
   --color-tag-color: var(--color-white);
   --color-tag-color-text-label: var(--color-neutral);
 


### PR DESCRIPTION
**PO-TAG**

**DTHFUI-1762**

***

**PR Checklist**

- [x] HTML
- [x] CSS

***

Agora o componente permite a utilização da paleta de cores além de ícones e navegação através do teclado.

UI: https://github.com/portinariui/portinari-angular/pull/98