### PR TITLE
fix(modal): corrige scroll ao usar po-url no IE/Edge

### DIFF
--- a/src/css/components/po-modal/po-modal.css
+++ b/src/css/components/po-modal/po-modal.css
@@ -113,7 +113,8 @@
   color: var(--color-modal-text-color-body);
   margin: 8px;
   max-width: 736px;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
   text-align: left;
 }
 


### PR DESCRIPTION
**PO-MODAL**

**DTHFUI-2060**

***

**PR Checklist**

- [ ] HTML
- [x] CSS

***

Agora o componente impede a geração de scroll na vertical do seu
conteúdo, corrigindo assim o comportamento nos navegadores
Internet Explorer e Microsoft Edge.