### PR TITLE
refactor(table): renomeado o seletor po-table-column-checkbox

### DIFF
--- a/src/css/components/po-field/po-lookup/po-lookup.html
+++ b/src/css/components/po-field/po-lookup/po-lookup.html
@@ -247,7 +247,7 @@
                           <table class="po-table">
                             <thead>
                               <tr class="po-table-header">
-                                <th class="po-table-column-checkbox">
+                                <th class="po-table-column-selectable">
                                 </th>
                                 <th class="po-table-header-ellipsis">
                                   <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
@@ -266,7 +266,7 @@
 
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio2" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio2"></label>
                                 </td>
@@ -286,7 +286,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio1" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio1"></label>
                                 </td>
@@ -306,7 +306,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox po-table-row-active">
+                                <td class="po-table-column po-table-column-selectable po-table-row-active">
                                   <input type="radio" id="radio3" class="po-radio-group-input po-radio-group-input-checked">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>
@@ -326,7 +326,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox ">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio3" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>
@@ -346,7 +346,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio3" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>
@@ -453,7 +453,7 @@
                           <table class="po-table">
                             <thead>
                               <tr class="po-table-header">
-                                <th class="po-table-column-checkbox">
+                                <th class="po-table-column-selectable">
                                 </th>
                                 <th class="po-table-header-ellipsis">
                                   <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
@@ -472,7 +472,7 @@
 
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio2" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio2"></label>
                                 </td>
@@ -492,7 +492,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio1" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio1"></label>
                                 </td>
@@ -512,7 +512,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio3" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>
@@ -532,7 +532,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox ">
+                                <td class="po-table-column po-table-column-selectable ">
                                   <input type="radio" id="radio3" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>
@@ -552,7 +552,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-checkbox">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio3" class="po-radio-group-input">
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -427,7 +427,7 @@
   white-space: nowrap;
 }
 
-.po-table .po-table-column-checkbox {
+.po-table .po-table-column-selectable {
   padding: 0 8px;
   min-width: 36px;
   max-width: 36px;
@@ -445,7 +445,7 @@
   width: 20px;
 }
 
-.po-table-column-checkbox .po-table-checkbox+.po-table-checkbox-label:before {
+.po-table-column-selectable .po-table-checkbox+.po-table-checkbox-label:before {
   border: solid 1px var(--color-table-border-select-checkbox);
   border-radius: 2px;
   box-shadow: inset 0px 2px 8px 0 var(--color-table-box-shadow-checkbox);
@@ -458,7 +458,7 @@
   width: 20px;
 }
 
-.po-table-column-checkbox .po-table-checkbox-checked+.po-table-checkbox-label:before,
+.po-table-column-selectable .po-table-checkbox-checked+.po-table-checkbox-label:before,
 .po-table-checkbox-indeterminate+.po-table-checkbox-label:before {
   background-color: var(--color-table-background-color-selected);
   border: solid 1px var(--color-table-border-selected-checkbox)!important;
@@ -469,7 +469,7 @@
   padding-left: 1px;
 }
 
-.po-table-column-checkbox .po-table-checkbox-checked+.po-table-checkbox-label:before {
+.po-table-column-selectable .po-table-checkbox-checked+.po-table-checkbox-label:before {
   content: '\e938';
 }
 
@@ -642,7 +642,7 @@
     padding: 8px 0;
   }
 
-  .po-table-column-checkbox .po-table-checkbox + .po-table-checkbox-label:before {
+  .po-table-column-selectable .po-table-checkbox + .po-table-checkbox-label:before {
     height: 18px;
     width: 18px;
   }

--- a/src/css/components/po-table/po-table.html
+++ b/src/css/components/po-table/po-table.html
@@ -2866,7 +2866,7 @@
             <table class="po-table">
               <thead>
                 <tr>
-                  <th class="po-table-column-checkbox">
+                  <th class="po-table-column-selectable">
                     <div class="po-table-header-fixed-inner">
                       <input type="checkbox" id="checkbox1" class="po-table-checkbox po-table-checkbox-indeterminate">
                       <label class="po-table-checkbox-label" for="checkbox1"></label>
@@ -2925,7 +2925,7 @@
 
               <tbody class="po-table-group-row">
                 <tr class="po-table-row">
-                  <td class="po-table-column po-table-column-checkbox">
+                  <td class="po-table-column po-table-column-selectable">
                     <div class="po-table-column-cell">
                       <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                       <label class="po-table-checkbox-label" for="checkbox2"></label>
@@ -2992,7 +2992,7 @@
               </tbody>
               <tbody class="po-table-group-row">
                 <tr class="po-table-row">
-                  <td class="po-table-column po-table-column-checkbox">
+                  <td class="po-table-column po-table-column-selectable">
                     <div class="po-table-column-cell">
                       <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                       <label class="po-table-checkbox-label" for="checkbox2"></label>
@@ -3043,7 +3043,7 @@
               </tbody>
               <tbody class="po-table-group-row">
                 <tr class="po-table-row">
-                  <td class="po-table-column po-table-column-checkbox">
+                  <td class="po-table-column po-table-column-selectable">
                     <div class="po-table-column-cell">
                       <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                       <label class="po-table-checkbox-label" for="checkbox2"></label>
@@ -3093,7 +3093,7 @@
               </tbody>
               <tbody class="po-table-group-row">
                 <tr class="po-table-row">
-                  <td class="po-table-column po-table-column-checkbox ">
+                  <td class="po-table-column po-table-column-selectable">
                     <div class="po-table-column-cell">
                       <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                       <label class="po-table-checkbox-label" for="checkbox2"></label>
@@ -3144,7 +3144,7 @@
               </tbody>
               <tbody class="po-table-group-row">
                 <tr class="po-table-row">
-                  <td class="po-table-column po-table-column-checkbox">
+                  <td class="po-table-column po-table-column-selectable">
                     <div class="po-table-column-cell">
                       <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                       <label class="po-table-checkbox-label" for="checkbox2"></label>
@@ -4099,7 +4099,7 @@
         <table class="po-table">
           <thead>
             <tr class="po-table-header">
-              <th class="po-table-column-checkbox">
+              <th class="po-table-column-selectable">
               </th>
               <th class="po-table-header-ellipsis">
                 <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
@@ -4129,7 +4129,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="radio" id="radio2" class="po-radio-group-input">
                 <label class="po-radio-group-label po-clickable" for="radio2"></label>
               </td>
@@ -4170,7 +4170,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="radio" id="radio1" class="po-radio-group-input">
                 <label class="po-radio-group-label po-clickable" for="radio1"></label>
               </td>
@@ -4209,7 +4209,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox po-table-row-active">
+              <td class="po-table-column po-table-column-selectable po-table-row-active">
                 <input type="radio" id="radio3" class="po-radio-group-input po-radio-group-input-checked">
                 <label class="po-radio-group-label po-clickable" for="radio3"></label>
               </td>
@@ -4260,7 +4260,7 @@
         <table class="po-table">
           <thead>
             <tr class="po-table-header">
-              <th class="po-table-column-checkbox">
+              <th class="po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" class="po-table-checkbox po-table-checkbox-indeterminate">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </th>
@@ -4292,7 +4292,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox2" class="po-table-checkbox">
                 <label class="po-table-checkbox-label" for="checkbox2"></label>
               </td>
@@ -4333,7 +4333,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox po-table-row-active">
+              <td class="po-table-column po-table-column-selectable po-table-row-active">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -4374,7 +4374,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox po-table-row-active">
+              <td class="po-table-column po-table-column-selectable po-table-row-active">
                 <input type="checkbox" id="checkbox3" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox3"></label>
               </td>
@@ -5125,7 +5125,7 @@
         <table class="po-table po-table-striped">
           <thead>
             <tr class="po-table-header">
-              <th class="po-table-column-checkbox">
+              <th class="po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" class="po-table-checkbox po-table-checkbox-indeterminate">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </th>
@@ -5158,7 +5158,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row po-table-row-active">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5204,7 +5204,7 @@
                   <tbody>
                     <tr class="po-table-detail-row po-table-row-active">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox">
+                      <td class="po-table-column po-table-column-selectable">
                         <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                         <label class="po-table-checkbox-label" for="checkbox1"></label>
                       </td>
@@ -5216,7 +5216,7 @@
 
                     <tr class="po-table-detail-row po-table-row-active">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox">
+                      <td class="po-table-column po-table-column-selectable">
                         <input type="checkbox" id="checkbox2" checked class="po-table-checkbox po-table-checkbox-checked">
                         <label class="po-table-checkbox-label" for="checkbox2"></label>
                       </td>
@@ -5228,7 +5228,7 @@
 
                     <tr class="po-table-detail-row">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox">
+                      <td class="po-table-column po-table-column-selectable">
                         <input type="checkbox" id="checkbox3" class="po-table-checkbox">
                         <label class="po-table-checkbox-label" for="checkbox3"></label>
                       </td>
@@ -5245,7 +5245,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row po-table-row-active">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5287,7 +5287,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5329,7 +5329,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5381,7 +5381,7 @@
         <table class="po-table po-table-striped">
           <thead>
             <tr class="po-table-header">
-              <th class="po-table-column-checkbox">
+              <th class="po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" class="po-table-checkbox po-table-checkbox-indeterminate">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </th>
@@ -5414,7 +5414,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row po-table-row-active">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5460,7 +5460,7 @@
                   <tbody>
                     <tr class="po-table-detail-row">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox"></td>
+                      <td class="po-table-column po-table-column-selectable"></td>
                       <td class="po-table-column-master-detail po-table-master-detail-label">
                         <strong>Pacote:</strong> Básico
                       </td>
@@ -5471,7 +5471,7 @@
 
                     <tr class="po-table-detail-row">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox"></td>
+                      <td class="po-table-column po-table-column-selectable"></td>
                       <td class="po-table-column-master-detail po-table-master-detail-label">
                         <strong> Pacote: </strong> Intermediário</td>
                       <td class="po-table-column-master-detail po-table-master-detail-label">
@@ -5481,7 +5481,7 @@
 
                     <tr class="po-table-detail-row">
                       <td class="po-table-column-master-detail-space-checkbox"></td>
-                      <td class="po-table-column po-table-column-checkbox"></td>
+                      <td class="po-table-column po-table-column-selectable"></td>
                       <td class="po-table-column-master-detail po-table-master-detail-label">
                         <strong>Pacote: </strong> Completo</td>
                       <td class="po-table-column-master-detail po-table-master-detail-label">
@@ -5496,7 +5496,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row po-table-row-active">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox po-table-checkbox-checked">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5539,7 +5539,7 @@
 
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>
@@ -5581,7 +5581,7 @@
           </tbody>
           <tbody class="po-table-group-row">
             <tr class="po-table-row">
-              <td class="po-table-column po-table-column-checkbox">
+              <td class="po-table-column po-table-column-selectable">
                 <input type="checkbox" id="checkbox1" checked class="po-table-checkbox">
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </td>


### PR DESCRIPTION
O seletor po-table-column-checkbox foi renomeado para po-table-column-selectable.

Fixes DTHFUI-2515

**OBS:** Ver PR no `portinari-angular`.